### PR TITLE
Improve mobile sidebar responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
             <a href="https://drive.google.com/drive/folders/1wT2HLSqZK0eMaAsRYa3kJI6lSA-GhiX_?usp=drive_link" target="_blank" rel="noopener noreferrer">Slide tài liệu</a>
 
     </div>
+    <button id="sidebarToggle" class="sidebar-toggle" onclick="toggleSidebar()">☰</button>
     <div class="content">
       <iframe id="viewer" src="01_intro.html" class="page-frame" data-default="01_intro.html"></iframe>
     </div>
@@ -55,6 +56,14 @@
         }
       });
     });
+    function toggleSidebar() {
+      const sidebar = document.querySelector(".sidebar");
+      const btn = document.getElementById("sidebarToggle");
+      if (!sidebar || !btn) return;
+      sidebar.classList.toggle("open");
+      document.body.classList.toggle("sidebar-open", sidebar.classList.contains("open"));
+      btn.textContent = sidebar.classList.contains("open") ? "✖" : "☰";
+    }
   </script>
 </body>
 

--- a/styles.css
+++ b/styles.css
@@ -960,3 +960,53 @@
     .tooltip:hover::after {
       opacity: 1;
     }
+/* Responsive sidebar toggle */
+.sidebar-toggle {
+  position: fixed;
+  top: 15px;
+  left: 15px;
+  z-index: 1201;
+  background: #021B79;
+  color: #fff;
+  border: none;
+  font-size: 1.8em;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  display: none;
+  transition: left 0.3s;
+}
+
+body.sidebar-open #sidebarToggle {
+  left: 335px;
+}
+
+@media (max-width:700px) {
+  .layout {
+    overflow-x: hidden;
+  }
+  .sidebar {
+    position: fixed;
+    left: -320px;
+    top: 0;
+    height: 100vh;
+    z-index: 1200;
+    transition: left 0.3s;
+  }
+  .sidebar.open {
+    left: 0;
+  }
+  .sidebar-toggle {
+    display: block;
+  }
+  .content {
+    width: 100vw;
+  }
+}
+
+@media (min-width:701px) {
+  .content {
+    width: calc(100vw - 320px);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add mobile toggle button in `index.html`
- implement sidebar open/close logic
- style responsive sidebar and toggle icon

## Testing
- `npm test`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6847baf5180c832b981d17af98b55fac